### PR TITLE
feat(popup): add element picker button with keyboard shortcut

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1,8 +1,15 @@
 .container{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;padding:10px 12px;min-width:240px;background:#fff;border:1px solid #d0d7de;border-radius:0;box-shadow:0 8px 24px rgba(31,35,40,0.08)}
 .title{font-size:14px;margin:0 0 8px 0;color:#24292f}
-.row{display:flex;align-items:center;justify-content:space-between;padding:8px 0;border-top:1px solid #eef2f7}
+.row{display:flex;align-items:center;justify-content:space-between;padding:8px 0}
 .row-text{font-size:13px;color:#1f2328}
 .hint{margin-top:6px;color:#57606a;font-size:12px}
+.group{margin-top:8px;border-top:1px solid #eef2f7}
+.actions{margin-top:0;display:block}
+.btn{appearance:none;border:1px solid #d0d7de;background:#f6f8fa;color:#24292f;border-radius:0;padding:6px 10px;font-size:12px;cursor:pointer;width:100%;display:flex;align-items:center;justify-content:space-between}
+.btn-primary{border-color:#1f883d;background:#2da44e;color:#fff}
+.btn:active{transform:translateY(0.5px)}
+.btn-text{text-align:left}
+.kbd{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;border:1px solid rgba(31,35,40,0.15);background:#fff;color:#24292f;padding:2px 6px;font-size:11px;line-height:1;border-radius:0}
 .switch{position:relative;display:inline-block;width:40px;height:22px}
 .switch input{opacity:0;width:0;height:0}
 .slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:#d0d7de;transition:all .2s;border-radius:22px}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -9,12 +9,22 @@
   <body>
     <div class="container">
       <h1 class="title" id="title">Title Picker</h1>
-      <div class="row">
-        <div class="row-text" id="label-text">Auto Restore This URL</div>
-        <label class="switch">
-          <input type="checkbox" id="toggle" />
-          <span class="slider"></span>
-        </label>
+      <div class="group">
+        <div class="actions">
+          <button class="btn btn-primary" id="btn-pick">
+            <span class="btn-text" id="btn-pick-text">Pick Element as Title</span>
+            <span class="kbd">Alt+T</span>
+          </button>
+        </div>
+      </div>
+      <div class="group">
+        <div class="row">
+          <div class="row-text" id="label-text">Auto Restore This URL</div>
+          <label class="switch">
+            <input type="checkbox" id="toggle" />
+            <span class="slider"></span>
+          </label>
+        </div>
       </div>
       <div class="hint" id="hint"></div>
     </div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -4,14 +4,18 @@
   const t = {
     title: isZh? "标题选择器" : "Title Picker",
     label: isZh? "为当前链接启用自动恢复" : "Auto Restore This URL",
+    pick: isZh? "选择页面元素作为标题" : "Pick Element as Title",
     hintOn: isZh? "已加入白名单：后续访问将恢复已保存标题" : "Whitelisted: future visits restore the saved title",
     hintOff: isZh? "未加入白名单：默认不自动恢复" : "Not whitelisted: no auto-restore by default",
+    pickOk: isZh? "已开启选择模式" : "Selection mode activated",
+    pickFail: isZh? "当前链接不支持" : "Not supported on this URL",
   };
 
   const $ = (id) => document.getElementById(id);
   $("title").textContent = t.title;
   $("hint").textContent = t.hintOff;
   $("label-text").textContent = t.label;
+  $("btn-pick-text").textContent = t.pick;
 
   function updateUI(checked){
     $("toggle").checked = !!checked;
@@ -24,6 +28,25 @@
         cb(tabs && tabs[0]);
       });
     } catch(_) { cb(null); }
+  }
+
+  function canInject(u){
+    try { return /^https?:\/\//.test(u); } catch(_) { return false; }
+  }
+
+  function onPick(){
+    getActiveTab((tab)=>{
+      const href = tab && tab.url ? tab.url : null;
+      if(!href || !canInject(href)) { $("hint").textContent = t.pickFail; return; }
+      try {
+        const p = chrome.scripting.executeScript({ target: { tabId: tab.id }, files: ["src/content/selector.js"] });
+        if (p && typeof p.then === "function") {
+          p.then(() => { window.close(); }).catch(() => { $("hint").textContent = t.pickFail; });
+        } else {
+          window.close();
+        }
+      } catch(_) { $("hint").textContent = t.pickFail; }
+    });
   }
 
   function load(){
@@ -56,5 +79,6 @@
   // prefix config removed
 
   $("toggle").addEventListener("change", toggleChange);
+  $("btn-pick").addEventListener("click", onPick);
   load();
 })();


### PR DESCRIPTION
Add a new button to pick page elements as titles with Alt+T shortcut. The button is styled with primary colors and includes keyboard shortcut hint. Added corresponding functionality in popup.js to handle the pick action and inject selector script.