### PR TITLE
feat(popup): add prefix matching for title auto-restore

### DIFF
--- a/src/content/selector.js
+++ b/src/content/selector.js
@@ -41,6 +41,16 @@
         const text = e.target.innerText.trim();
         if (text) {
             chrome.storage.local.set({ [location.href]: text });
+            try {
+                chrome.storage.local.get(["autoRestorePrefixes"], (res) => {
+                    const pl = Array.isArray(res.autoRestorePrefixes) ? res.autoRestorePrefixes : [];
+                    const href = location.href;
+                    const matches = pl.filter(p => typeof p === "string" && href.startsWith(p));
+                    matches.sort((a,b)=> b.length - a.length);
+                    const longest = matches[0];
+                    if (longest) chrome.storage.local.set({ [longest]: text });
+                });
+            } catch (_) {}
             document.title = text;
         }
 

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -113,6 +113,16 @@
     const text = input.value.trim();
     if (text) {
       chrome.storage.local.set({ [location.href]: text });
+      try {
+        chrome.storage.local.get(["autoRestorePrefixes"], (res) => {
+          const pl = Array.isArray(res.autoRestorePrefixes) ? res.autoRestorePrefixes : [];
+          const href = location.href;
+          const matches = pl.filter(p => typeof p === "string" && href.startsWith(p));
+          matches.sort((a,b)=> b.length - a.length);
+          const longest = matches[0];
+          if (longest) chrome.storage.local.set({ [longest]: text });
+        });
+      } catch (_) {}
       document.title = text;
     }
     cleanup();

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -2,6 +2,8 @@
 .title{font-size:14px;margin:0 0 8px 0;color:#24292f}
 .row{display:flex;align-items:center;justify-content:space-between;padding:8px 0}
 .row-text{font-size:13px;color:#1f2328}
+.row-input{padding:8px 0;overflow-y: auto;}
+.input{width:100%;border:1px solid #d0d7de;padding:6px 8px;font-size:12px;border-radius:0}
 .hint{margin-top:6px;color:#57606a;font-size:12px}
 .group{margin-top:8px;border-top:1px solid #eef2f7}
 .actions{margin-top:0;display:block}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -25,6 +25,16 @@
             <span class="slider"></span>
           </label>
         </div>
+        <div class="row">
+          <div class="row-text" id="label-prefix-text">Prefix Restore</div>
+          <label class="switch">
+            <input type="checkbox" id="toggle-prefix" />
+            <span class="slider"></span>
+          </label>
+        </div>
+        <div class="row-input">
+          <input type="text" id="prefix-input" class="input" placeholder="Prefix to match (e.g. https://site/path)" />
+        </div>
       </div>
       <div class="hint" id="hint"></div>
     </div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -4,6 +4,7 @@
   const t = {
     title: isZh? "标题选择器" : "Title Picker",
     label: isZh? "为当前链接启用自动恢复" : "Auto Restore This URL",
+    labelPrefix: isZh? "前缀匹配恢复" : "Prefix Restore",
     pick: isZh? "选择页面元素作为标题" : "Pick Element as Title",
     hintOn: isZh? "已加入白名单：后续访问将恢复已保存标题" : "Whitelisted: future visits restore the saved title",
     hintOff: isZh? "未加入白名单：默认不自动恢复" : "Not whitelisted: no auto-restore by default",
@@ -15,6 +16,8 @@
   $("title").textContent = t.title;
   $("hint").textContent = t.hintOff;
   $("label-text").textContent = t.label;
+  const lp = document.getElementById("label-prefix-text");
+  if (lp) lp.textContent = t.labelPrefix;
   $("btn-pick-text").textContent = t.pick;
 
   function updateUI(checked){
@@ -53,9 +56,19 @@
     getActiveTab((tab)=>{
       const href = tab && tab.url ? tab.url : null;
       if(!href){ updateUI(false); return; }
-      chrome.storage.local.get(["autoRestoreUrls"], (res)=>{
+      chrome.storage.local.get(["autoRestoreUrls","autoRestorePrefixes","autoRestorePrefixDisabledUrls"], (res)=>{
         const list = Array.isArray(res.autoRestoreUrls) ? res.autoRestoreUrls : [];
         updateUI(list.includes(href));
+        const pList = Array.isArray(res.autoRestorePrefixes) ? res.autoRestorePrefixes : [];
+        const dList = Array.isArray(res.autoRestorePrefixDisabledUrls) ? res.autoRestorePrefixDisabledUrls : [];
+        const matches = pList.filter(p => typeof p === "string" && href.startsWith(p));
+        matches.sort((a,b)=> b.length - a.length);
+        const longest = matches[0] || "";
+        const pt = document.getElementById("toggle-prefix");
+        const pi = document.getElementById("prefix-input");
+        const disabled = dList.includes(href);
+        if (pt) pt.checked = !!longest && !disabled;
+        if (pi) pi.value = longest || href;
       });
     });
   }
@@ -76,9 +89,57 @@
     });
   }
 
+  function togglePrefixChange(){
+    const checked = document.getElementById("toggle-prefix").checked;
+    const typed = (document.getElementById("prefix-input").value || "").trim();
+    getActiveTab((tab)=>{
+      const href = tab && tab.url ? tab.url : null;
+      if(!href) return;
+      chrome.storage.local.get(["autoRestorePrefixes","autoRestorePrefixDisabledUrls"], (res)=>{
+        const pList = Array.isArray(res.autoRestorePrefixes) ? res.autoRestorePrefixes : [];
+        const next = new Set(pList);
+        const disabledList = Array.isArray(res.autoRestorePrefixDisabledUrls) ? res.autoRestorePrefixDisabledUrls : [];
+        const nextDisabled = new Set(disabledList);
+        if (checked) {
+          if (typed) next.add(typed);
+          nextDisabled.delete(href);
+        } else {
+          if (typed === href) {
+            next.delete(typed);
+          } else {
+            nextDisabled.add(href);
+          }
+        }
+        chrome.storage.local.set({ autoRestorePrefixes: Array.from(next), autoRestorePrefixDisabledUrls: Array.from(nextDisabled) }, load);
+      });
+    });
+  }
+
+  function onPrefixInput(){
+    const typed = (document.getElementById("prefix-input").value || "").trim();
+    const checked = document.getElementById("toggle-prefix").checked;
+    if (!checked) return;
+    getActiveTab((tab)=>{
+      const href = tab && tab.url ? tab.url : null; if(!href) return;
+      chrome.storage.local.get(["autoRestorePrefixes","autoRestorePrefixDisabledUrls"], (res)=>{
+        const pList = Array.isArray(res.autoRestorePrefixes) ? res.autoRestorePrefixes : [];
+        const next = new Set(pList);
+        if (typed) next.add(typed);
+        const disabledList = Array.isArray(res.autoRestorePrefixDisabledUrls) ? res.autoRestorePrefixDisabledUrls : [];
+        const nextDisabled = new Set(disabledList);
+        nextDisabled.delete(href);
+        chrome.storage.local.set({ autoRestorePrefixes: Array.from(next), autoRestorePrefixDisabledUrls: Array.from(nextDisabled) });
+      });
+    });
+  }
+
   // prefix config removed
 
   $("toggle").addEventListener("change", toggleChange);
   $("btn-pick").addEventListener("click", onPick);
+  const tpf = document.getElementById("toggle-prefix");
+  if (tpf) tpf.addEventListener("change", togglePrefixChange);
+  const pin = document.getElementById("prefix-input");
+  if (pin) pin.addEventListener("input", onPrefixInput);
   load();
 })();


### PR DESCRIPTION
Implement prefix matching functionality to allow auto-restoring titles for URLs matching a specified prefix. Includes UI changes for prefix input and toggle, and updates to storage logic to handle prefix matching and disabled URLs.